### PR TITLE
suggesting single quotes by default in javascript

### DIFF
--- a/style/javascript.md
+++ b/style/javascript.md
@@ -134,8 +134,14 @@ if (!someVariable) {
 
 ## 6) Strings
 
+Strings should use double quotes `'` where possible, and double quotes `"` when necessary, just as in python.
 
-Strings should use double quotes (“) instead of single quotes (‘)
+```js
+var good = 'a string';
+var alsoGood = "When you need 'apostrophes' then double-quotes won't hurt";
+
+var notGood = "double quotes for no reason"
+```
 
 ## 7) Method and property visibility
 


### PR DESCRIPTION
I brought this up in hipchat a few weeks ago, and there seemed to be no one who was violently opposed to changing this style point.

Is everyone cool with this?

Reasons:
- consistency with python
- fewer characters

Reasons not to:
- I couldn't think of any
