### PR TITLE
Make python.md more accurate about how imports work

### DIFF
--- a/style/python.md
+++ b/style/python.md
@@ -47,11 +47,9 @@ from auth import models              # code uses models.Token -- ambiguous!
 from auth import oauth_credentials   # code uses oauth_credentials.Token -- clear
 ```
 
-> Rationale: This is the single best -- and easiest -- way to avoid the circular-import problem. To simplify, when you say import x python basically just needs to see that x.py exists, but when you say from x import foo python needs to actually read x.py, to ensure that foo is in there. When x does a 'from-import' from y, and y does a 'from-import' from x, there's no ordering where python can read both files in full, and a circular import ensues.
+> Rationale: This is the single best -- and easiest -- way to avoid the circular-import problem. To simplify, when you say import x Python executes the x.py file, but doesn't need to get any attributes from it.  When you say from x import foo Python needs x.py to be executed enough that foo is defined in it.  When x does a 'from-import' from y, and y does a 'from-import' from x, the circular import can succeed if a partial module is enough (as it will be with import x), but it can fail if the circularity happens before the needed attribute is defined (as it might be with from x import foo).
 
-> Another way to think about it is saying import x allows python to do a two-phase load of x: at import time it loads x's contents but doesn't try to parse them, and then when you first need a symbol from x, python does the parsing. But you probably don't need a symbol from x until someone calls a function you wrote that uses x.whatever. But calling of functions happens after __main__ executes, which is after all the imports have happened.
-
-> *Side note:* While this rule helps with most circular-import problems, it doesn’t help with all: python may still need to look up symbols from x even at parse time. For instance, if you say class xclass(y.yclass): ..., python needs to parse y at import-time.
+> *Side note:* While this rule helps with most circular-import problems, it doesn’t help with all: Python may still need to look up symbols from x even at parse time. For instance, if you say class xclass(y.yclass): ..., Python the yclass attribute at import-time.
 
 The downside of this rule is that code gets more verbose: where before you could do
 


### PR DESCRIPTION
I really like this style guide, but the import machinery explanation was wrong.  Providing this detail is good, but it should be accurate.  I hope it isn't presumptuous to provide an edit. :)