### PR TITLE
Modify AndroidStudio XML config to use hungarian notation

### DIFF
--- a/configs/KhanAcademyAndroid.xml
+++ b/configs/KhanAcademyAndroid.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <code_scheme name="KhanAcademyAndroid">
+  <option name="FIELD_NAME_PREFIX" value="m" />
+  <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
   <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />


### PR DESCRIPTION
review please @alangpierce @NachoSoto @mgp 

I know that it's a bit disconcerting at first, but just to reiterate the arguments for using it:

 - it's not actually that bad. and once you get used to it, it feels pretty good
 - note that public fields are excluded from the `m` prefix, so if we did immutable POJO's with no getters, it would still look like `Topic.title` or whatever
 - I think consistency with the Android codebase is nice, esp if we have to inherit framework classes to do stuff and use their protected fields (e.g. `CursorAdapter` or `CursorWrapper`)