### PR TITLE
Remove blank line from multi-line comment section

### DIFF
--- a/style/javascript.md
+++ b/style/javascript.md
@@ -213,7 +213,6 @@ JSDoc can be parsed by a number of open source tools, and must be well-formed.
 Syntax:
 ```js
 /**
-
  * A JSDoc comment should begin with a slash and 2 asterisks.
  */
 ```


### PR DESCRIPTION
I could just be missing something silly :) but it seems like there shouldn't be a blank line here?