### PR TITLE
Add note about static import preferences

### DIFF
--- a/style/java.md
+++ b/style/java.md
@@ -17,6 +17,11 @@ Import statements are divided into the following groups, in this order, with eac
 
 Imports are not subject to the 100 column limit rule; they should never be wrapped.
 
+We prefer using static imports when using the following:
+
+- `com.google.common.base.Preconditions.*` (e.g. `checkNotNull`)
+- `org.junit.Assert.*` (e.g. `assertEquals`)
+
 
 ## No per-file boilerplate
 


### PR DESCRIPTION
For `Preconditions`, we kind of have a mixture of both in our Android codebase.

```
$ git grep -l 'import static .*Preconditions.*;' | wc -l
      50

$ git grep -l 'import .*Preconditions;' | wc -l
      77
```

but I'm thinking we might want the static one. @alangpierce @NachoSoto @mgp ?