### PR TITLE
Encourage space before `/>` in self closing XML tags

### DIFF
--- a/configs/KhanAcademyAndroid.xml
+++ b/configs/KhanAcademyAndroid.xml
@@ -44,6 +44,7 @@
     </option>
   </AndroidXmlCodeStyleSettings>
   <XML>
+    <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
   </XML>
   <codeStyleSettings language="XML">


### PR DESCRIPTION
Before: `<foo bar="baz"/>`
After: `<foo bar="baz" />`

