### PR TITLE
Changes to imports in Android Studio style

### DIFF
--- a/configs/KhanAcademyAndroid.xml
+++ b/configs/KhanAcademyAndroid.xml
@@ -1,7 +1,6 @@
 <code_scheme name="KhanAcademyAndroid">
   <option name="FIELD_NAME_PREFIX" value="m" />
   <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
-  <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
@@ -42,6 +41,9 @@
       </value>
     </option>
   </AndroidXmlCodeStyleSettings>
+  <JavaCodeStyleSettings>
+    <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
+  </JavaCodeStyleSettings>
   <XML>
     <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />


### PR DESCRIPTION
- Don't insert imports for inner classes
- Always insert imports for classes referenced in {@link} javadocs

cc @alangpierce @mgp @benkomalo 