### PR TITLE
Revamp the style guide formatting, rewrite it, and add a few rules.

### DIFF
--- a/style/react.md
+++ b/style/react.md
@@ -1,34 +1,11 @@
-# React style guide
+## React style guide
 
-**Follow the normal Javascript style guide - including the 80 character limit. In addition there are several React-specific rules.**
+> Follow the normal Javascript style guide - including the 80 character limit. In addition there are several React-specific rules.
 
-## props vs state
+----------
+### Syntax
 
-You almost always want to use [props, not state](http://facebook.github.io/react/docs/interactivity-and-dynamic-uis.html).
-
-Copying data from props to state can cause the UI to get out of sync form the underlying data models because what's displayed no longer directly tracks what's stored. Instead, strive to have data in one place instead of copying it, which ensures that everything is consistent.
-
-## When and how do you use Backbone models?
-
-You probably shouldn't. **TODO: expand**
-
-## Use [propTypes](http://facebook.github.io/react/docs/reusable-components.html)
-
-Use it for every prop. This is the place to go to figure out which props need to be passed to a model. Great [example](http://jsfiddle.net/spicyj/DEpwb/).
-
-Make sure you understand required, instance, enum, and custom PropTypes.
-
-## Minimize use of jQuery
-
-With React, jQuery should
-
-- *never* be used for DOM manipulation
-- rarely be used for ajax - Backbone can usually take care of this for you
-- rarely be used for plugins - I recommend wrapping the jQuery plugin with a React component so you only have to touch the jQuery once
-
-In a similar vein, *never* store information in the DOM (using data- attributes or classes). All information should be stored in Javascript. Note: this rule probably applied before but is worth emphasizing with React. Ask Joel if you want to hear a rant on this subject.
-
-## Name handlers `handleEventName`
+#### Name handlers `handleEventName`
 
 Example:
 
@@ -36,36 +13,24 @@ Example:
 <Component onClick={this.handleClick} onLaunchMissiles={this.handleLaunchMissiles} />
 ```
 
-As you may have noticed there is also a convention to name a handler that your component takes as a parameter `onEventName`. This is consistent with React's event naming - `onClick`, `onDrag`, `onChange`, etc.
+As you may have noticed there is also a convention to name a handler
+that your component takes as a parameter `onEventName`. This is
+consistent with React's event naming - `onClick`, `onDrag`,
+`onChange`, etc.
 
-## Standard components
 
-**TODO: update this list**
+#### Open elements on the same line.
 
-react-package provides several standard components, and there are more to come.
+80 chars is a bit tight so we opt to conserve the extra 4.
 
-- SetIntervalMixin - provides a setInterval method so something can be done every x milliseconds
-- Animation - still a work in progress. demo
-
-More KA-specific
-
-- TimeAgo - “five minutes ago”, etc - this replaces $.timeago
-- UserHoverable - the thing where you can hover over a username
-- blink, rumble, shudder, sparkle - for some reason React doesn’t come with these built in
-- etc - a lot of components have been built and they’re all supremely reusable
-
-For now (until the rise of the New Package Manager) drop any reusable components (anything you could see someone else using) you've made in react-package. Also, let everyone know what you've built. Email the team and blog it.
-
-## Open elements on the same line
-
+Yes:
 ```jsx
 return <div>
    ...
 </div>;
 ```
 
-not
-
+No:
 ```jsx
 return (
     <div>
@@ -74,29 +39,128 @@ return (
 );
 ```
 
-80 chars is a bit tight so we opt to conserve the extra 4.
+#### Align properties.
 
-## Align properties
+Fit them all on the same line if you can, but put them all in the same
+column if you have to break.  This makes it easy to see the props at a
+glance.
 
-Fit them all on the same line if you can, but put them all in the same column if you have to break.
-
-Good:
-
-`<div className="highlight" key="highlight-div">`
-
-Good
-
+Yes:
 ```jsx
+<div className="highlight" key="highlight-div">
 <div
     className="highlight"
     key="highlight-div">
 ```
 
-Bad
-
+No:
 ```jsx
 <div className="highlight"
-    key="highlight-div"
+     key="highlight-div"
 ```
 
-This makes it easy to see the props at a glance.
+#### Only export a single react class.
+
+Every .jsx file should export a single react class, and nothing else.
+This is for testability: the fixture framework requires it to
+function.
+
+Note the file can still define multiple classes, it just can't export
+more than one.
+
+
+---------------------
+### Language features
+
+#### Prefer [props to state](http://facebook.github.io/react/docs/interactivity-and-dynamic-uis.html).
+
+You almost always want to use props.  Copying data from props to state
+can cause the UI to get out of sync from the underlying data models
+because what's displayed no longer directly tracks what's stored.  By
+having the data in one place instead of copying it, you ensure
+everything is consistent.
+
+#### Use [propTypes](http://facebook.github.io/react/docs/reusable-components.html).
+
+React Components should always have complete propTypes.  Every
+attribute of this.props should have a corresponding entry in
+propTypes.  This documents that props need to be passed to a model.
+([example](http://jsfiddle.net/spicyj/DEpwb/))
+
+Avoid these non-descriptive prop-types:
+   * `React.PropTypes.any`
+   * `React.PropTypes.array`
+   * `React.PropTypes.object`
+
+Instead, use 
+   * `React.PropTypes.arrayOf`
+   * `React.PropTypes.objectOf`
+   * `React.PropTypes.instanceOf`
+   * `React.PropTypes.shape`
+
+An exception is if you are simply passing the data to a child component.
+
+#### Make "dumb" components pure.
+
+It's useful to think of the React world as divided into "smart"
+components and "dumb" components.
+
+"Smart" components have application logic, but do not emit HTML
+themselves.
+
+"Dumb" components are typically reusable, and do emit HTML.
+
+Smart components can have internal state, but dumb components never
+should.
+
+#### *Never* store state in the DOM.
+
+Do not use data- attributes or classes).  All information should be
+stored in Javascript, either in the React component itself, or in a
+React store if using a framework such as Redux.
+
+
+----------------------------------
+### React libraries and components
+
+#### Do not use Backbone models.
+
+TODO
+
+#### Minimize use of jQuery.
+
+*Never* use jQuery for DOM manipulation.
+
+Use native promises instead of jQuery promises.
+
+Try to avoid using jQuery plugins.  When necessary, wrap the jQuery
+plugin with a React component so you only have to touch the jQuery
+once.
+
+You can use `$.ajax` (but no other function, such as $.post) for
+network communication.
+
+#### Reuse standard components.
+
+If possible, re-use existing "dumb" components (pure components that
+emit html directly).  If you write a new one, as soon as it finds one
+other client put it in a shared location.
+
+The standard shared location for useful components provided *by the
+React team* is the `react-components` package in
+`javascript-packages.json`.  This includes components such as these:
+
+* `SetIntervalMixin` - provides a setInterval method so something can be
+  done every x milliseconds
+* `$_` - the i18n wrapper to allow for translating text in React.
+* `TimeAgo` - “five minutes ago”, etc - this replaces $.timeago
+
+Reusable components *written internally* are in the (poorly named)
+`react.js` package.  This include components such as these:
+
+* `KUIButton` - render a Khan Academy styled button.
+* `Modal` - create a modal dialog.
+
+This list is far from complete.
+
+### 


### PR DESCRIPTION
Summary:
Maybe I should have done this as separate commits, but the file is
small enough I think it's reasonable to deal with them all in one go.

Major formatting changes:

* We use h3 and h4 rather than h2 and h3, which makes more of the
  style guide fit on a screen at a time, and in general improves
  readability (I think).
* The style guide is now divided into logical sections ("formatting,"
  "libraries," etc.), each with a small number of items in them.  I
  think this improves readability as well.
* I have standardized on 'yes'/'no' text for examples, rather than
  sometimes having 'good'/'bad'.  I like 'yes' or 'no': style guides
  should be opinionated.

Likewise, I reworded a bunch of stuff to say "do this, do that" rather
than just "this is good, that is good."  Other rewording was mostly to
tighten the text.  I also got rid of some obsolete text (such as a
mention of the new package system, which never materialized).  I also
tried to rewrite the 'standard components' section so it doesn't get
out of date quite so quickly.

I added two new rules:

* Only export a single react class.  This came out of the best
  practices doc at
  https://docs.google.com/document/d/1ChtFUao18IyNhaXZ5sE2W-CFuFcYnqlFTyi5gfe6XV0/edit#heading=h.10yidnt3j9ml
* Some discussion about "dumb" and "smart" components.

I also tightened the rule about using propTypes.

Test Plan:
I installed a markdown viewer plugin in my browser and visited
   file:///home/csilvers/khan/style-guides/style/react.md
and saw that the page rendered in a way that looked good, at least to
me.