### PR TITLE
Adds .eslintrc and a "readme" for how to set up react/js linting.

### DIFF
--- a/configs/.eslintrc
+++ b/configs/.eslintrc
@@ -1,0 +1,33 @@
+{
+  "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
+  "ecmaFeatures": {
+    "jsx": true,
+    "modules": true
+  },
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "rules": {
+    "eol-last": [0],
+    "indent": [2, 4],
+    "comma-dangle": [2, "never"],
+    "max-len": [1, 79, 4],
+    "no-unused-vars": 1,
+    "quotes": [2, "single"],
+    "semi": [2, "always"],
+    "space-after-keywords": [2, "always"],
+    "space-before-blocks": 2,
+    "space-before-function-paren": [2, { "anonymous": "always", "named": "never" }],
+    "strict": [1, "never"],
+    "react/sort-comp": [2],
+    "react/jsx-no-undef": 2,
+    "react/jsx-uses-react": 2,
+    "react/jsx-uses-vars": 2,
+    "react/react-in-jsx-scope": 2,
+    "react/prop-types": 2,
+  }
+}

--- a/configs/package.json
+++ b/configs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "khan-style-guides",
+  "version": "0.1.0",
+  "description": "We implement a style guide for our code with the intention of keeping things readable and consistent. Please do your part on the team to help keep the spirit of this consistency in both your own code, as well as politely pointing out violations in other people's code when doing their code reviews. While code prettiness should never be valued over launching or any user-visible impacting changes to the code, the idea is that maintaining a readable codebase helps things be more maintainable, and in the long run will make it easier to do the real changes that do make user-visible changes.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/khan/style-guides.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/khan/style-guides/issues"
+  },
+  "homepage": "https://github.com/khan/style-guides#readme",
+  "dev-dependencies": {
+    "babel-eslint": "^4.1.3",
+    "eslint": "^1.6.0",
+    "eslint-plugin-react": "^3.5.1"
+  }
+}

--- a/configs/readme.md
+++ b/configs/readme.md
@@ -1,0 +1,24 @@
+# style and linting configuration
+
+## android studio
+
+komalo or nacho know what to do with the `KhanAcademyAndroid.xml` file.
+
+## javascript/react
+
+you can get eslint reminding you to write better code as you edit by setting up
+this linter.
+
+It's pretty straight forward! `npm install` this and use this `.eslintrc` and
+you'll get a fancy pants eslint setup that you can integrate with your favorite
+editor!
+
+but if you don't like this package.json nonsense, you can do
+
+    npm install --save-dev eslint
+    npm install --save-dev babel-eslint
+    npm install --save-dev eslint-plugin-react
+
+and that will basically do the same thing. you're in the clear as long as the
+bundled `.eslintrc` is in a root dir of your webapp.
+


### PR DESCRIPTION
summary: linting's easier when a computer does it for you.

The package.json basically has the three packages needed for the
.eslintrc file to work its magic.

this mostly works, but is unable to catch many of the philosophical 
points outlined in the style guide, although it does enforce many 
extant ka style-isms.

test plan: yolo

reviewers: nose goes!