### PR TITLE
Add a carriage return between the list and the dotted line

### DIFF
--- a/style/react.md
+++ b/style/react.md
@@ -17,6 +17,7 @@
   * [Do not use Backbone models.](#do-not-use-backbone-models)
   * [Minimize use of jQuery.](#minimize-use-of-jquery)
   * [Reuse standard components.](#reuse-standard-components)
+
 ----
 
 > Follow the normal [Javascript style guide](javascript.md) - including the 80 character line limit. In addition there are several React-specific rules.


### PR DESCRIPTION
This fixes a Markdown parsing issue.

Before:

* item
* item
----


After:

* item
* item

----