### PR TITLE
Fix broken link in table of contents

### DIFF
--- a/style/react.md
+++ b/style/react.md
@@ -2,7 +2,7 @@
 
 ----
 * [Syntax](#syntax)
-  * [Use ES6 classes.](#use-es6-classes)
+  * [Use ES6 classes.](#use-es2015-classes)
   * [Component method and property ordering](#component-method-and-property-ordering)
   * [Name handlers handleEventName.](#name-handlers-handleeventname)
   * [Name handlers in props onEventName.](#name-handlers-in-props-oneventname)


### PR DESCRIPTION
Fix the ES6 classes link in the table of contents